### PR TITLE
fix: populate %ThumbnailMode% so thumbnail_mode config takes effect

### DIFF
--- a/a3m/server/packages.py
+++ b/a3m/server/packages.py
@@ -36,6 +36,16 @@ BASE_REPLACEMENTS = {
     r"%rejectedDirectory%": _get_setting("REJECTED_DIRECTORY"),
 }
 
+# String forms expected by the normalize client script's --thumbnail_mode
+# argument, keyed by the ThumbnailMode protobuf enum.
+_PROCESSING_CONFIG = transfer_service_api.request_response_pb2.ProcessingConfig
+THUMBNAIL_MODE_STRINGS = {
+    _PROCESSING_CONFIG.THUMBNAIL_MODE_UNSPECIFIED: "generate",
+    _PROCESSING_CONFIG.THUMBNAIL_MODE_GENERATE: "generate",
+    _PROCESSING_CONFIG.THUMBNAIL_MODE_GENERATE_NON_DEFAULT: "generate_non_default",
+    _PROCESSING_CONFIG.THUMBNAIL_MODE_DO_NOT_GENERATE: "do_not_generate",
+}
+
 
 def get_file_replacement_mapping(file_obj, unit_directory):
     mapping = BASE_REPLACEMENTS.copy()
@@ -283,6 +293,8 @@ class Package:
                 for config_attr in transfer_service_api.request_response_pb2.ProcessingConfig.DESCRIPTOR.fields
             }
         )
+
+        mapping[r"%ThumbnailMode%"] = THUMBNAIL_MODE_STRINGS[self.config.thumbnail_mode]
 
         if self.stage is Stage.INGEST:
             mapping.update(

--- a/tests/server/test_package.py
+++ b/tests/server/test_package.py
@@ -65,6 +65,40 @@ def test_transfer_get_or_create_from_db_path_without_uuid(tmp_path):
         )
 
 
+class FakeUnit:
+    def __init__(self, pk, currentlocation="/tmp/fake-unit"):
+        self.pk = pk
+        self.currentlocation = currentlocation
+
+
+@pytest.mark.parametrize(
+    "thumbnail_mode,expected",
+    [
+        (ProcessingConfig.THUMBNAIL_MODE_UNSPECIFIED, "generate"),
+        (ProcessingConfig.THUMBNAIL_MODE_GENERATE, "generate"),
+        (
+            ProcessingConfig.THUMBNAIL_MODE_GENERATE_NON_DEFAULT,
+            "generate_non_default",
+        ),
+        (ProcessingConfig.THUMBNAIL_MODE_DO_NOT_GENERATE, "do_not_generate"),
+    ],
+)
+def test_replacement_mapping_resolves_thumbnail_mode(thumbnail_mode, expected):
+    """The workflow passes --thumbnail_mode "%ThumbnailMode%" to the normalize
+    client script, which expects the string forms below."""
+    package = Package(
+        "test-package",
+        "file:///tmp/foobar.gz",
+        ProcessingConfig(thumbnail_mode=thumbnail_mode),
+        FakeUnit(uuid.uuid4()),
+        FakeUnit(uuid.uuid4()),
+    )
+
+    mapping = package.get_replacement_mapping()
+
+    assert mapping[r"%ThumbnailMode%"] == expected
+
+
 @pytest.fixture
 def workflow(request):
     with open(INTEGRATION_TEST_PATH) as workflow_file:


### PR DESCRIPTION
## Problem

The "Normalize for thumbnails" workflow link passes `--thumbnail_mode "%ThumbnailMode%"` to the normalize client script, but nothing ever populated `%ThumbnailMode%` in the replacement mapping (the config block only exposes `%config:thumbnail_mode%`, which renders the raw enum integer). The literal string `%ThumbnailMode%` therefore reached the script, matched none of the recognised modes, and fell through to full generation: `THUMBNAIL_MODE_DO_NOT_GENERATE` and `THUMBNAIL_MODE_GENERATE_NON_DEFAULT` were silent no-ops.

## Fix

Map the `ThumbnailMode` protobuf enum to the string forms the script expects (`generate`, `generate_non_default`, `do_not_generate`) and expose it as `%ThumbnailMode%` in `Package.get_replacement_mapping`. `UNSPECIFIED` maps to `generate`, preserving current default behaviour.

## Testing

New parametrised test covering all four enum values (written first, failed with `KeyError: '%ThumbnailMode%'`). Full `./test.sh` gate green: ruff, mypy, 172 passed pytest, pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thumbnail mode configuration is now properly included in package processing, supporting generate, generate non-default, and do not generate options for workflow normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->