### PR TITLE
fix: create DIP directory with mkdir -p so manual access normalization survives

### DIFF
--- a/a3m/assets/workflow.json
+++ b/a3m/assets/workflow.json
@@ -1090,7 +1090,7 @@
     "47c83e01-7556-4c13-881f-282c6d9c7d6a": {
       "config": {
         "@manager": "linkTaskManagerDirectories",
-        "arguments": "-m 770 \"%SIPDirectory%DIP/\" \"%SIPDirectory%DIP/objects/\"",
+        "arguments": "-p -m 770 \"%SIPDirectory%DIP/\" \"%SIPDirectory%DIP/objects/\"",
         "execute": "cmd_mkdir"
       },
       "description": {

--- a/tests/server/test_workflow.py
+++ b/tests/server/test_workflow.py
@@ -98,3 +98,16 @@ def test_get_schema_not_found(mocker):
     mocker.patch("a3m.server.workflow._LATEST_SCHEMA", "non-existen-schema")
     with pytest.raises(IOError):
         workflow._get_schema()
+
+
+def test_create_dip_directory_tolerates_existing_directory():
+    """The "Move access files to DIP" link (manual normalization) creates
+    %SIPDirectory%DIP/ during ingest, before "Create DIP directory" runs in
+    the generate_dip branch. mkdir must therefore be invoked with -p or the
+    link fails and the whole DIP branch is skipped via its fallback."""
+    with open(os.path.join(ASSETS_DIR, "workflow.json")) as fp:
+        wf = workflow.load(fp)
+    ln = wf.get_link("47c83e01-7556-4c13-881f-282c6d9c7d6a")
+    assert ln.get_label("description") == "Create DIP directory"
+    arguments = ln.config["arguments"]
+    assert arguments.startswith("-p "), arguments


### PR DESCRIPTION
## Problem

For a transfer containing `objects/manualNormalization/access/` files with `generate_dip=true`, the "Move access files to DIP" link (ingest phase) creates `%SIPDirectory%DIP/` via `os.makedirs` before the "Create DIP directory" link runs in the generate_dip branch. That link ran `mkdir -m 770` without `-p`, which exits 1 because `DIP/` already exists. With only exit code 0 mapped, the link fell back to "Prepare AIP" (status Failed): the entire DIP branch (access normalization, thumbnail generation, the DIP move to `dips/`) was skipped, no DIP was produced, and the manually normalized access files were silently dropped because `DIP/` is not a bag payload entry.

## Fix

Add `-p` to the mkdir arguments. Pre-existing directories are tolerated, and since both `DIP/` and `DIP/objects/` are named operands, `-m 770` still applies to each when created.

## Testing

New regression test loads the shipped workflow.json and asserts the link's arguments (written first, failed on the old `-m 770` arguments). Full `./test.sh` gate green: ruff, mypy, pytest, pre-commit.