### PR TITLE
fix: stop terminal-job failures releasing two queue slots

### DIFF
--- a/a3m/server/queues.py
+++ b/a3m/server/queues.py
@@ -183,7 +183,7 @@ class PackageQueue:
 
         # Pass package to callback so we can deactivate on failure
         job_done_callback = functools.partial(
-            self._job_completed_callback, job.package, job.link.id
+            self._job_completed_callback, job.package, job.link
         )
         result.add_done_callback(job_done_callback)
 
@@ -233,7 +233,7 @@ class PackageQueue:
         self.deactivate_package(package)
         self.queue_next_job()
 
-    def _job_completed_callback(self, package, link_id, future):
+    def _job_completed_callback(self, package, link, future):
         """Schedule the next job in the chain.
 
         Retrieve the next job from the result from the previous job. If there is
@@ -248,10 +248,16 @@ class PackageQueue:
             logger.error(
                 "Job execution failed for package %s (link %s) with exception: %s",
                 package.uuid,
-                link_id,
+                link.id,
                 err,
                 exc_info=True,
             )
+            if link.is_terminal:
+                # _package_completed_callback is also registered on this
+                # future and owns recovery; deactivating and admitting the
+                # next package here too would release two queue slots for a
+                # single freed one.
+                return
             # Job failed - deactivate package so it doesn't block the queue
             self.deactivate_package(package)
             self.queue_next_job()

--- a/tests/server/test_queues.py
+++ b/tests/server/test_queues.py
@@ -160,3 +160,74 @@ def test_queue_next_job_raises_full(
 
     with pytest.raises(queue.Full):
         package_queue.queue_next_job()
+
+
+@pytest.fixture
+def terminal_link(request):
+    return Link(
+        uuid.uuid4(),
+        {
+            "config": {
+                "@manager": "linkTaskManagerDirectory",
+                "@model": "StandardTaskConfig",
+                "arguments": "",
+                "execute": "testLink_v0",
+            },
+            "description": {"en": "A terminal test link"},
+            "exit_codes": {
+                "0": {"job_status": "Completed successfully", "link_id": None}
+            },
+            "fallback_job_status": "Failed",
+            "fallback_link_id": None,
+            "group": {"en": "Testing"},
+            "end": True,
+        },
+        object(),
+    )
+
+
+class FailingMockJob(MockJob):
+    def run(self, *args, **kwargs):
+        self.job_ran.set()
+        raise Exception("simulated job crash")
+
+
+def test_terminal_job_failure_releases_a_single_slot(
+    simple_executor, package, package_2, terminal_link, workflow_link, mocker
+):
+    """A failing terminal job triggers both the job and the package completed
+    callbacks. Recovery (deactivate + admit next package) must happen exactly
+    once, or one finished package admits two queued ones."""
+    package_queue = PackageQueue(
+        simple_executor, max_concurrent_packages=1, max_queued_packages=2, debug=True
+    )
+    package_3 = SIP(
+        "package-3",
+        "file:///tmp/foobar-3.gz",
+        ProcessingConfig(),
+        FakeUnit("mno"),
+        FakeUnit("pqr"),
+    )
+
+    failing_job = FailingMockJob(mocker.Mock(), terminal_link, package)
+    queued_job_2 = MockJob(mocker.Mock(), workflow_link, package_2)
+    queued_job_3 = MockJob(mocker.Mock(), workflow_link, package_3)
+
+    package_queue.schedule_job(failing_job)
+    package_queue.schedule_job(queued_job_2)
+    package_queue.schedule_job(queued_job_3)
+
+    assert package_queue.sip_queue.qsize() == 2
+
+    package_queue.process_one_job(timeout=0.1)
+
+    failing_job.job_ran.wait(1.0)
+    # The done callbacks run in the single worker thread before it picks up
+    # new work, so a barrier task guarantees they have finished.
+    simple_executor.submit(lambda: None).result(timeout=5.0)
+
+    assert package.uuid not in package_queue.active_packages
+    # Exactly one queued package may take the freed slot.
+    assert len(package_queue.active_packages) == 1
+    assert package_queue.job_queue.qsize() == 1
+    assert package_queue.sip_queue.qsize() == 1


### PR DESCRIPTION
## Problem

For terminal links, `process_one_job` registers both `_job_completed_callback` and `_package_completed_callback` on the same future. Since the queue-recovery change, both callbacks catch a raised job exception and both run `deactivate_package` + `queue_next_job`, so a single freed slot admits **two** queued packages:

- active package count creeps past `max_concurrent_packages` (one extra per failed terminal job), and
- when the job queue is full, the second `queue_next_job` raises `queue.Full` from `put_nowait` inside the done callback **after** `activate_package` ran, leaving that package marked active with its job never enqueued: stuck forever, silently (the exception is swallowed by `concurrent.futures` callback handling).

## Fix

`_package_completed_callback` owns recovery for terminal links. `_job_completed_callback` now receives the link (not just its id), still decrements the active-jobs gauge, and returns early on terminal-link failures instead of double-recovering. Non-terminal failure recovery is unchanged.

## Testing

New test schedules a failing terminal job with two packages queued and a concurrency limit of 1, then asserts exactly one package is admitted. Written first: it failed with two active packages and the swallowed `queue.Full` visible in captured logs. Full `./test.sh` gate green: ruff, mypy, pytest, pre-commit.