### PR TITLE
fix: use class constant for package type in SIPDIP.get_or_create_from_db_by_path

### DIFF
--- a/a3m/server/packages.py
+++ b/a3m/server/packages.py
@@ -379,7 +379,9 @@ class SIPDIP(Package):
     def get_or_create_from_db_by_path(cls, path):
         """Matches a directory to a database SIP by its appended UUID, or path."""
         path = path.replace(_get_setting("SHARED_DIRECTORY"), r"%sharedPath%", 1)
-        package_type = cls.unit_variable_type
+        # cls.unit_variable_type is a property descriptor at class level, so
+        # the class constant must be used here.
+        package_type = cls.UNIT_VARIABLE_TYPE
         sip_uuid = uuid_from_path(path)
         created = True
         if sip_uuid:

--- a/tests/server/test_package.py
+++ b/tests/server/test_package.py
@@ -15,6 +15,7 @@ from a3m.server.workflow import load as load_workflow
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 INTEGRATION_TEST_PATH = os.path.join(FIXTURES_DIR, "workflow-integration-test.json")
 from a3m.server.packages import DIP
+from a3m.server.packages import SIP
 from a3m.server.packages import Transfer
 
 
@@ -26,9 +27,10 @@ def test_dip_get_or_create_from_db_path_without_uuid(tmp_path):
 
     assert dip.current_path == str(dip_path)
     try:
-        models.SIP.objects.get(uuid=dip.uuid)
+        sip_model = models.SIP.objects.get(uuid=dip.uuid)
     except models.SIP.DoesNotExist:
         pytest.fail("DIP.get_or_create_from_db_by_path didn't create a SIP model")
+    assert sip_model.sip_type == "DIP"
 
 
 @pytest.mark.django_db(transaction=True)
@@ -41,9 +43,29 @@ def test_dip_get_or_create_from_db_path_with_uuid(tmp_path):
     assert dip.uuid == dip_uuid
     assert dip.current_path == str(dip_path)
     try:
-        models.SIP.objects.get(uuid=dip_uuid)
+        sip_model = models.SIP.objects.get(uuid=dip_uuid)
     except models.SIP.DoesNotExist:
         pytest.fail("DIP.get_or_create_from_db_by_path didn't create a SIP model")
+    assert sip_model.sip_type == "DIP"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_sip_get_or_create_from_db_path_updates_current_path(tmp_path):
+    sip_uuid = uuid.uuid4()
+    old_path = tmp_path / "old-location" / f"test-sip-{sip_uuid}"
+    new_path = tmp_path / "new-location" / f"test-sip-{sip_uuid}"
+    sip_model = models.SIP.objects.create(
+        uuid=sip_uuid, currentpath=str(old_path), sip_type="SIP"
+    )
+    models.Transfer.objects.create(uuid=sip_uuid, currentlocation=str(old_path))
+    sip_model.transfer_id = str(sip_uuid)
+
+    sip = SIP.get_or_create_from_db_by_path(str(new_path))
+
+    assert str(sip.uuid) == str(sip_uuid)
+    sip_model = models.SIP.objects.get(uuid=sip_uuid)
+    assert sip_model.sip_type == "SIP"
+    assert sip_model.currentpath == str(new_path)
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Problem

`SIPDIP.get_or_create_from_db_by_path` read `cls.unit_variable_type`, which at class level resolves to the property descriptor inherited from `Package`, not a string. Consequences:

- new SIP rows were saved with `sip_type` set to the string repr `<property object at 0x...>` (CharField coerces via `str()`): silently stored past `max_length=8` on SQLite and an error on stricter backends such as PostgreSQL,
- the `package_type == "SIP"` guard could never match, so the existing-row `currentpath` update branch was dead.

Today this code path is only exercised by tests (runtime packages are built by `Package.create_package`), but it breaks the moment anything constructs DIP/SIP packages by path.

## Fix

Use the `UNIT_VARIABLE_TYPE` class constant that the `DIP`/`SIP` subclasses define.

## Testing

Existing DIP tests extended to assert the stored `sip_type` (failed first with `'<property ob...>' == 'DIP'`), plus a new test for the SIP currentpath-update branch (failed first with the stale path). Full `./test.sh` gate green: ruff, mypy, pytest, pre-commit. One unreproducible single-test failure occurred on the very first fresh-DB run after the fix; three subsequent full runs (including `--create-db` and a cold DB) were green, so it looks like a first-run ordering flake rather than this change, but flagging for transparency.