### PR TITLE
fix: correct error-path bugs in DIP client scripts

### DIFF
--- a/a3m/client/clientScripts/copy_recursive.py
+++ b/a3m/client/clientScripts/copy_recursive.py
@@ -7,7 +7,7 @@ def call(jobs):
     for job in jobs:
         with job.JobContext():
             if not os.path.isdir(job.args[1]):
-                return
+                continue
 
             exit_code, std_out, std_error = executeOrRun(
                 "command", ["cp", "-R"] + job.args[1:], capture_output=True

--- a/a3m/client/clientScripts/manual_normalization_move_access_files_to_dip.py
+++ b/a3m/client/clientScripts/manual_normalization_move_access_files_to_dip.py
@@ -107,13 +107,13 @@ def main(job):
             if isinstance(e, File.DoesNotExist):
                 job.print_error(
                     "No matching file for: ",
-                    opts.filePath.replace(opts.SIPDirectory, "%SIPDirectory%", 1),
+                    opts.filePath.replace(opts.sipDirectory, "%SIPDirectory%", 1),
                 )
                 return 3
             elif isinstance(e, File.MultipleObjectsReturned):
                 job.print_error(
                     "Too many possible files for: ",
-                    opts.filePath.replace(opts.SIPDirectory, "%SIPDirectory%", 1),
+                    opts.filePath.replace(opts.sipDirectory, "%SIPDirectory%", 1),
                 )
                 return 2
 

--- a/tests/client/test_copy_recursive.py
+++ b/tests/client/test_copy_recursive.py
@@ -1,0 +1,26 @@
+import uuid
+
+from a3m.client.clientScripts import copy_recursive
+from a3m.client.job import Job
+
+
+def test_copy_recursive_processes_remaining_jobs_after_missing_source(tmp_path):
+    """A missing source directory means nothing to copy for that job, but the
+    remaining jobs in the batch must still run."""
+    missing_src = tmp_path / "does-not-exist"
+    src = tmp_path / "src"
+    (src / "sub").mkdir(parents=True)
+    (src / "sub" / "file.txt").write_text("content")
+    dst = tmp_path / "dst"
+    dst.mkdir()
+
+    job_missing = Job(
+        "copy_recursive", str(uuid.uuid4()), [str(missing_src), str(dst)]
+    )
+    job_real = Job("copy_recursive", str(uuid.uuid4()), [str(src), str(dst)])
+
+    copy_recursive.call([job_missing, job_real])
+
+    assert (dst / "src" / "sub" / "file.txt").exists()
+    assert job_missing.get_exit_code() == 0
+    assert job_real.get_exit_code() == 0

--- a/tests/client/test_copy_recursive.py
+++ b/tests/client/test_copy_recursive.py
@@ -14,9 +14,7 @@ def test_copy_recursive_processes_remaining_jobs_after_missing_source(tmp_path):
     dst = tmp_path / "dst"
     dst.mkdir()
 
-    job_missing = Job(
-        "copy_recursive", str(uuid.uuid4()), [str(missing_src), str(dst)]
-    )
+    job_missing = Job("copy_recursive", str(uuid.uuid4()), [str(missing_src), str(dst)])
     job_real = Job("copy_recursive", str(uuid.uuid4()), [str(src), str(dst)])
 
     copy_recursive.call([job_missing, job_real])

--- a/tests/client/test_manual_normalization_move_access_files_to_dip.py
+++ b/tests/client/test_manual_normalization_move_access_files_to_dip.py
@@ -1,0 +1,30 @@
+import os
+import uuid
+
+import pytest
+
+from a3m.client.clientScripts import manual_normalization_move_access_files_to_dip
+from a3m.client.job import Job
+
+
+@pytest.mark.django_db
+def test_unmatched_access_file_without_csv_reports_missing_original(tmp_path):
+    """When no original matches the access file and there is no
+    normalization.csv, the job must fail with exit code 3 and a readable
+    message, not crash."""
+    sip_uuid = str(uuid.uuid4())
+    sip_dir = str(tmp_path) + os.sep
+    file_path = os.path.join(
+        sip_dir, "objects", "manualNormalization", "access", "foo.txt"
+    )
+
+    job = Job(
+        "manual_normalization_move_access_files_to_dip",
+        str(uuid.uuid4()),
+        ["--sipUUID", sip_uuid, "--sipDirectory", sip_dir, "--filePath", file_path],
+    )
+
+    manual_normalization_move_access_files_to_dip.call([job])
+
+    assert job.get_exit_code() == 3
+    assert "No matching file" in job.get_stderr()


### PR DESCRIPTION
## Problem

Two defects introduced with the DIP reintegration, both on error paths (invisible on the happy path):

1. **copy_recursive** ("Copy OCR data to DIP directory") returned from `call()` when a job's source directory was missing, abandoning every remaining job in the batch. Each abandoned job reports the default exit code 0 (success), so a batched run would silently skip work and still look successful.
2. **manual_normalization_move_access_files_to_dip** referenced `opts.SIPDirectory` in its no-CSV `File.DoesNotExist` / `File.MultipleObjectsReturned` branches, but the optparse destination is `sipDirectory`. The branch meant to print "No matching file for" / "Too many possible files for" and return exit 3/2 instead raised `AttributeError`, which `JobContext` converts to a generic exit 1, losing the diagnostic.

## Fix

- `continue` instead of `return` in copy_recursive so the rest of the batch runs.
- Use `opts.sipDirectory` in both move-script error branches.

## Testing

- copy_recursive: a batch where the first job has a missing source and the second is valid; assert the second job's files were copied and both jobs exit 0 (failed first: the valid job was skipped).
- move script: an unmatched access file with no normalization.csv; assert exit code 3 and the "No matching file" message (failed first with exit 1 from the swallowed AttributeError).

Full `./test.sh` gate green: ruff, mypy, pytest, pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Copy recursive script now continues processing remaining jobs when a source directory is missing, instead of stopping prematurely.
* Error message formatting in the manual normalization script is now consistently applied across error-handling scenarios.

## Tests
* Added test coverage for processing multiple jobs in copy recursive operations.
* Added test coverage for missing file error reporting in manual normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->